### PR TITLE
Add tx language map zh-Hans→zh_Hans and update strings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,52 @@
+# Common settings that generally should always be used with your language specific settings
+
+# Auto detect text files and perform LF normalization
+*          text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+# Documents
+*.html     text diff=html
+*.md       text diff=markdown
+*.pdf      binary diff=astextplain
+*.txt      text
+
+# Graphics
+*.ico      binary
+*.png      binary
+*.tif      binary
+
+# Scripts
+*.sh       text eol=lf
+/ocr       text eol=lf
+*.bat      text eol=crlf
+
+#
+# Exclude files from exporting
+#
+.gitattributes text export-ignore
+.gitignore     text export-ignore
+.gitkeep       text export-ignore
+
+# Java sources
+*.form          text
+*.groovy        text diff=java
+*.java          text diff=java
+
+# These files are text and should be normalized (Convert crlf => lf)
+*.aff              text
+*.dic              text
+*.properties       text
+*.xml              text
+.tx/config         text
+manifest.mf        text
+tessdata/configs/* text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.dll           binary
+*.jar           binary
+*.traineddata   binary
+*.ttf           binary

--- a/.tx/config
+++ b/.tx/config
@@ -1,5 +1,6 @@
 [main]
 host = https://www.transifex.com
+lang_map: zh-Hans: zh_Hans
 
 [o:vietocr:p:vietocr:r:BulkDialog_properties]
 file_filter            = src/net/sourceforge/vietocr/BulkDialog_<lang>.properties

--- a/src/net/sourceforge/vietocr/OptionsDialog_zh_Hans.properties
+++ b/src/net/sourceforge/vietocr/OptionsDialog_zh_Hans.properties
@@ -29,3 +29,5 @@ jCheckBoxRemoveHyphens.Text=\u5220\u9664\u8f6f\u8fde\u5b57\u7b26
 jCheckBoxRemoveHyphens.ToolTipText=\u5220\u9664\u6362\u884c\u7b26\u540e\u5220\u9664\u8f6f\u8fde\u5b57\u7b26
 jCheckBoxDeskew.Text=\u89d2\u5ea6\u77eb\u6b63
 Hyphens=\u8fde\u5b57\u7b26
+jCheckBoxRemoveLines.Text=\u5220\u9664\u884c
+jCheckBoxRemoveLineBreaks.Text=\u5220\u9664\u6362\u884c\u7b26


### PR DESCRIPTION
In #30 I didn't notice that Chinese Simplified language files were duplicated. The Transifex mapping will prevent that in the future. Also, a couple new strings seem to have been translated to Chinese at some point, so adding them too.